### PR TITLE
Fix frontend import paths

### DIFF
--- a/frontend/src/components/ui/CreatePostModal.tsx
+++ b/frontend/src/components/ui/CreatePostModal.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import apiClient from '../services/api';
+import apiClient from '../../services/api';
 
 // 親コンポーネントから受け取るPropsの型を定義
 type CreatePostModalProps = {

--- a/frontend/src/components/ui/Timeline.tsx
+++ b/frontend/src/components/ui/Timeline.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import apiClient from '../services/api';
+import apiClient from '../../services/api';
 
 // 投稿データの型を定義
 interface Post {

--- a/frontend/src/pages/MainPage.tsx
+++ b/frontend/src/pages/MainPage.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import UserInfo from '../components/ui/UserInfo';
-import Timeline from '../components/Timeline';
-import CreatePostModal from '../components/CreatePostModal';
+import Timeline from '../components/ui/Timeline';
+import CreatePostModal from '../components/ui/CreatePostModal';
 
 // 親コンポーネント(App.tsx)から受け取る関数の型を定義
 type MainPageProps = {


### PR DESCRIPTION
## Summary
- correct relative paths for API client imports
- fix component import paths in MainPage

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684abb8ef984832386f8c3af08dedcd9