### PR TITLE
Fix uvicorn module path

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -10,9 +10,9 @@ COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
 # アプリケーションのコード全体をコピーします
-COPY ./app /app
+COPY ./app /app/app
 
 # コンテナが起動したときに実行されるコマンド
 # uvicornサーバーを起動し、どのIPからのアクセスも受け付けるようにします
 # --reloadフラグで、コードが変更されたら自動でサーバーを再起動してくれます
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     ports:
       - "8000:8000"
     volumes:
-      - ./backend/app:/app
+      - ./backend/app:/app/app
     env_file:
       - ./backend/.env
 


### PR DESCRIPTION
## Summary
- run uvicorn against `app.main` in the backend container
- mount backend `app` folder inside the container at `/app/app`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684abf73cb748323ab2ea4e8630e7a1e