### PR TITLE
Fix runtime error by adding python-multipart and update Pydantic configs

### DIFF
--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -23,7 +23,7 @@ class Post(PostBase):
 
     # SQLAlchemyモデルからPydanticモデルへ変換するために必要なおまじない
     class Config:
-        orm_mode = True
+        from_attributes = True
 
 
 # --- User Schemas ---
@@ -42,7 +42,7 @@ class User(UserBase):
     id: int
 
     class Config:
-        orm_mode = True
+        from_attributes = True
 
 
 # --- Token Schemas ---

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -16,5 +16,8 @@ python-jose[cryptography]
 # .env ファイルを読み込むため
 python-dotenv
 
+# Form data parsing for OAuth2PasswordRequestForm
+python-multipart
+
 pytest
 requests


### PR DESCRIPTION
## Summary
- add missing `python-multipart` dependency for OAuth2 form data
- switch Pydantic `Config` to use `from_attributes` for v2 compatibility

## Testing
- `pip install -r requirements.txt`
- `pip install httpx`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ac0b489a08323914bd0f79c3a213f