### PR TITLE
Load DB URL from env

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1,16 +1,21 @@
+import os
 from sqlalchemy import create_engine
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
 
 # データベースファイルの場所を定義します。
 # 'sqlite:///./musatoku.db' は、カレントディレクトリにある musatoku.db ファイルを意味します。
-SQLALCHEMY_DATABASE_URL = "sqlite:///./musatoku.db"
+# データベースの接続URLを環境変数から取得し、設定されていなければSQLiteを使用します。
+SQLALCHEMY_DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./musatoku.db")
 
 # SQLAlchemyの「エンジン」を作成します。これがデータベースとの実際の接続点となります。
-# `connect_args` はSQLiteを使用する際に推奨される設定です。
-engine = create_engine(
-    SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False}
-)
+# SQLiteを使う場合のみ `check_same_thread` オプションを指定します。
+if SQLALCHEMY_DATABASE_URL.startswith("sqlite"):
+    engine = create_engine(
+        SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False}
+    )
+else:
+    engine = create_engine(SQLALCHEMY_DATABASE_URL)
 
 # データベースとの「会話」（セッション）を管理するためのクラスを作成します。
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)


### PR DESCRIPTION
## Summary
- make the database URL configurable via `DATABASE_URL`
- only use SQLite `connect_args` when necessary

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ae29793b0832390cc904890955bcb