### PR TITLE
Ignore pytest cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ dist/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pytest_cache/


### PR DESCRIPTION
## Summary
- ignore `.pytest_cache/` in `.gitignore`

## Testing
- `pip install -q -r backend/requirements.txt`
- `pytest` *(fails: SECRET_KEY environment variable is required)*

------
https://chatgpt.com/codex/tasks/task_e_684ae3694bec8323ba36384375804736