### PR TITLE
Pin httpx version

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,13 @@ Password: pass
 }
 解説:
 この設定により、VSCodeのDev Container機能を使った際に、PythonやTailwind CSS、Dockerの便利な拡張機能が自動でインストールされるようになります。
+
+## Python依存関係
+
+バックエンドでは `httpx` を Starlette との互換性を保つため `0.27` 未満に固定しています。
+ローカルでテストを実行する際は以下のコマンドでインストールしてください。
+
+```bash
+cd backend
+pip install -r requirements.txt
+```

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -21,4 +21,4 @@ python-multipart
 
 pytest
 requests
-httpx
+httpx<0.27


### PR DESCRIPTION
## Summary
- keep httpx under 0.27 in backend requirements
- mention the version constraint and install command in README

## Testing
- `pip install -r requirements.txt` within `backend`
- `SECRET_KEY=test pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ae4262ff48323947458a4fc4181a6