### PR TITLE
Add dockerignore for frontend

### DIFF
--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+*.log
+.dockerignore
+Dockerfile
+.git
+.gitignore


### PR DESCRIPTION
## Summary
- add a `.dockerignore` for the frontend

## Testing
- `export SECRET_KEY=test && pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ae6a68bf08323a32d898b8b5d9e62