### PR TITLE
Add department model and user relation

### DIFF
--- a/backend/app/crud.py
+++ b/backend/app/crud.py
@@ -12,9 +12,10 @@ def create_user(db: Session, user: schemas.UserCreate):
     """ユーザーを新規作成します。"""
     hashed_password = auth.get_password_hash(user.password)
     db_user = models.User(
-        employee_id=user.employee_id, 
-        name=user.name, 
-        hashed_password=hashed_password
+        employee_id=user.employee_id,
+        name=user.name,
+        hashed_password=hashed_password,
+        department_id=user.department_id,
     )
     db.add(db_user)
     db.commit()

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -5,6 +5,16 @@ from datetime import datetime, timezone
 # No.7で作成したdatabase.pyから、全てのモデルが継承するBaseクラスをインポートします
 from .database import Base
 
+
+class Department(Base):
+    __tablename__ = "departments"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, unique=True, nullable=False)
+
+    # backreference to users
+    users = relationship("User", back_populates="department")
+
 class User(Base):
     __tablename__ = "users"  # データベース内でのテーブル名を指定
 
@@ -13,6 +23,13 @@ class User(Base):
     employee_id = Column(String, unique=True, index=True, nullable=False)
     name = Column(String, default="名無しさん") # ニックネーム機能を見越してデフォルト値設定
     hashed_password = Column(String, nullable=False)
+    department_id = Column(Integer, ForeignKey("departments.id"))
+
+    department = relationship("Department", back_populates="users")
+
+    @property
+    def department_name(self):
+        return self.department.name if self.department else None
 
     # リレーションシップの定義: UserとPostを連携させます
     # これにより、あるユーザーがした投稿一覧を簡単に取得できるようになります

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -32,6 +32,7 @@ class Post(PostBase):
 class UserBase(BaseModel):
     employee_id: str
     name: str
+    department_id: Optional[int] = None
 
 # ユーザーを作成する際に受け取るデータ型（パスワードを含む）
 class UserCreate(UserBase):
@@ -40,6 +41,7 @@ class UserCreate(UserBase):
 # API経由で返すユーザーのデータ型（パスワードは含めない）
 class User(UserBase):
     id: int
+    department_name: Optional[str] = None
 
     class Config:
         from_attributes = True


### PR DESCRIPTION
## Summary
- add new `Department` model
- link `User` to `Department` with `department_id`
- allow creating users with a department in CRUD
- expose department info through Pydantic schemas

## Testing
- `pip install -r backend/requirements.txt`
- `export SECRET_KEY=testsecret`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b89c89e388323a9a2e4dec9edb5fb