### PR TITLE
Add department name to user responses

### DIFF
--- a/backend/app/crud.py
+++ b/backend/app/crud.py
@@ -1,4 +1,4 @@
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, joinedload
 from datetime import timezone
 from . import models, schemas, auth
 
@@ -6,7 +6,12 @@ from . import models, schemas, auth
 
 def get_user_by_employee_id(db: Session, employee_id: str):
     """社員IDを元にユーザーを一件取得します。"""
-    return db.query(models.User).filter(models.User.employee_id == employee_id).first()
+    return (
+        db.query(models.User)
+        .options(joinedload(models.User.department))
+        .filter(models.User.employee_id == employee_id)
+        .first()
+    )
 
 def create_user(db: Session, user: schemas.UserCreate):
     """ユーザーを新規作成します。"""

--- a/backend/app/tests/test_main.py
+++ b/backend/app/tests/test_main.py
@@ -38,3 +38,19 @@ def test_post_timestamp_timezone():
         # ensure ISO 8601 can be parsed and includes tzinfo
         parsed = datetime.fromisoformat(created_at.replace("Z", "+00:00"))
         assert parsed.tzinfo is not None
+
+
+def test_user_department_name():
+    """/users/me should include the department name"""
+    with TestClient(app) as client:
+        token_resp = client.post(
+            "/token",
+            data={"username": "000000", "password": "pass"},
+        )
+        assert token_resp.status_code == 200
+        token = token_resp.json()["access_token"]
+
+        headers = {"Authorization": f"Bearer {token}"}
+        user_resp = client.get("/users/me", headers=headers)
+        assert user_resp.status_code == 200
+        assert user_resp.json().get("department_name") == "テスト部署"


### PR DESCRIPTION
## Summary
- load user's department when querying user info
- setup test department and ensure default user belongs to it on startup
- test for department_name field

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b8e58a9988323ae1a5948f944a7dd