### PR TITLE
Support user mentions in posts

### DIFF
--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -11,12 +11,14 @@ class PostBase(BaseModel):
 
 # 投稿を作成する際に受け取るデータ型
 class PostCreate(PostBase):
-    pass
+    # IDs of users mentioned in this post
+    mention_user_ids: list[int] = []
 
 # フロントエンドに返す投稿のデータ型
 class Post(PostBase):
     id: int
     created_at: datetime
+    mention_user_ids: list[int] = []
 
     # ★★★計画書通り、ここには投稿者の情報を含めません★★★
     # これにより、タイムラインの匿名性を保証します。

--- a/backend/app/tests/test_main.py
+++ b/backend/app/tests/test_main.py
@@ -54,3 +54,31 @@ def test_user_department_name():
         user_resp = client.get("/users/me", headers=headers)
         assert user_resp.status_code == 200
         assert user_resp.json().get("department_name") == "テスト部署"
+
+
+def test_post_mentions():
+    """posts can mention users"""
+    with TestClient(app) as client:
+        # login
+        token_resp = client.post(
+            "/token",
+            data={"username": "000000", "password": "pass"},
+        )
+        assert token_resp.status_code == 200
+        token = token_resp.json()["access_token"]
+
+        headers = {"Authorization": f"Bearer {token}"}
+
+        # get current user id
+        me_resp = client.get("/users/me", headers=headers)
+        assert me_resp.status_code == 200
+        user_id = me_resp.json()["id"]
+
+        # create post mentioning the current user
+        post_resp = client.post(
+            "/posts/",
+            json={"content": "hello", "mention_user_ids": [user_id]},
+            headers=headers,
+        )
+        assert post_resp.status_code == 201
+        assert user_id in post_resp.json().get("mention_user_ids", [])


### PR DESCRIPTION
## Summary
- add association table `post_mentions`
- add mention relationships and property on models
- extend schemas to include `mention_user_ids`
- update CRUD for mentions
- adjust tests for mention functionality

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b90d960e88323ba42236d1096364d