### PR TITLE
Add timeline tabs

### DIFF
--- a/frontend/src/components/ui/Timeline.tsx
+++ b/frontend/src/components/ui/Timeline.tsx
@@ -11,6 +11,7 @@ interface Post {
 // 親コンポーネントから受け取るPropsの型を定義
 type TimelineProps = {
   postSuccessTrigger: boolean;
+  endpoint: string;
 };
 
 // 日付を見やすい形式（例：「5分前」）に変換するヘルパー関数
@@ -31,7 +32,7 @@ const formatRelativeTime = (isoString: string): string => {
 };
 
 
-const Timeline: React.FC<TimelineProps> = ({ postSuccessTrigger }) => {
+const Timeline: React.FC<TimelineProps> = ({ postSuccessTrigger, endpoint }) => {
   const [posts, setPosts] = useState<Post[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -40,7 +41,7 @@ const Timeline: React.FC<TimelineProps> = ({ postSuccessTrigger }) => {
     const fetchPosts = async () => {
       try {
         setLoading(true);
-        const response = await apiClient.get<Post[]>('/posts/');
+        const response = await apiClient.get<Post[]>(endpoint);
         setPosts(response.data);
         setError(null);
       } catch (err) {
@@ -52,8 +53,8 @@ const Timeline: React.FC<TimelineProps> = ({ postSuccessTrigger }) => {
     };
 
     fetchPosts();
-    // ★★★ postSuccessTriggerが変更されたら、投稿を再取得します ★★★
-  }, [postSuccessTrigger]);
+    // postSuccessTriggerまたはendpointが変更されたら、投稿を再取得します
+  }, [postSuccessTrigger, endpoint]);
 
   if (loading && posts.length === 0) {
     return <div className="p-4 text-center text-gray-500">タイムラインを読み込んでいます...</div>;

--- a/frontend/src/pages/MainPage.tsx
+++ b/frontend/src/pages/MainPage.tsx
@@ -16,6 +16,9 @@ const MainPage: React.FC<MainPageProps> = ({ onLogout }) => {
   // これを更新することでタイムラインの再読み込みをトリガーします。
   const [postSuccess, setPostSuccess] = useState(false);
 
+  // 現在選択されているタイムラインタブ
+  const [activeTab, setActiveTab] = useState<'all' | 'mentioned'>('all');
+
   const handlePostSuccess = () => {
     setIsModalOpen(false); // モーダルを閉じる
     setPostSuccess(!postSuccess); // タイムラインの再読み込みをトリガー
@@ -41,10 +44,34 @@ const MainPage: React.FC<MainPageProps> = ({ onLogout }) => {
 
         {/* --- 中央カラム (メインタイムライン) --- */}
         <main className="col-span-6 border-l border-r border-gray-200">
-          <div className="p-4 border-b border-gray-200">
-            <h2 className="text-xl font-bold">ホーム</h2>
+          <div className="border-b border-gray-200">
+            <div className="flex">
+              <button
+                className={`flex-1 p-4 text-center font-semibold focus:outline-none ${
+                  activeTab === 'all'
+                    ? 'border-b-2 border-blue-500 text-blue-600'
+                    : 'text-gray-500'
+                }`}
+                onClick={() => setActiveTab('all')}
+              >
+                All Posts
+              </button>
+              <button
+                className={`flex-1 p-4 text-center font-semibold focus:outline-none ${
+                  activeTab === 'mentioned'
+                    ? 'border-b-2 border-blue-500 text-blue-600'
+                    : 'text-gray-500'
+                }`}
+                onClick={() => setActiveTab('mentioned')}
+              >
+                Mentioned Posts
+              </button>
+            </div>
           </div>
-          <Timeline postSuccessTrigger={postSuccess} />
+          <Timeline
+            postSuccessTrigger={postSuccess}
+            endpoint={activeTab === 'all' ? '/posts/' : '/posts/mentioned'}
+          />
         </main>
         
         {/* --- 右カラム (空きスペース) --- */}


### PR DESCRIPTION
## Summary
- add ability to switch between all posts and mentioned posts
- fetch posts from the selected endpoint
- highlight currently active tab

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`
- `cd frontend && npm install && npm run build && npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684b9988dfcc8323bc4d9d46d821cf17