### PR TITLE
Fix jaconv CJS import with custom types

### DIFF
--- a/frontend/src/types/jaconv.d.ts
+++ b/frontend/src/types/jaconv.d.ts
@@ -1,7 +1,8 @@
 declare module 'jaconv' {
   const jaconv: {
-    toKatakana: (s: string) => string;
-    toHanKana: (s: string) => string;
+    toKanaKana: (input: string) => string;
+    toKatakana: (input: string) => string;
+    toHanKana: (input: string) => string;
   };
-  export default jaconv;
+  export = jaconv;
 }


### PR DESCRIPTION
## Summary
- declare `jaconv` module to satisfy TypeScript

## Testing
- `npm run build`
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_684fd843a2e88323a2f7c8c9a9154b64