### PR TITLE
Fix jaconv import and types

### DIFF
--- a/frontend/src/types/jaconv.d.ts
+++ b/frontend/src/types/jaconv.d.ts
@@ -1,8 +1,4 @@
-declare module 'jaconv' {
-  const jaconv: {
-    toKanaKana: (input: string) => string;
-    toKatakana: (input: string) => string;
-    toHanKana: (input: string) => string;
-  };
-  export = jaconv;
+declare module "jaconv" {
+  const jaconv: any;
+  export default jaconv;
 }

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -16,6 +16,10 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true
   },
+  "typeRoots": [
+    "./src/types",
+    "./node_modules/@types"
+  ],
   "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }


### PR DESCRIPTION
## Summary
- add a default export for the `jaconv` type definition
- configure `typeRoots` so custom types are found

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684fda19e5848323aef7e01ec5bb8170