### PR TITLE
Implement admin user listing API

### DIFF
--- a/backend/app/crud.py
+++ b/backend/app/crud.py
@@ -21,11 +21,23 @@ def create_user(db: Session, user: schemas.UserCreate):
         name=user.name,
         hashed_password=hashed_password,
         department_id=user.department_id,
+        is_admin=user.is_admin,
     )
     db.add(db_user)
     db.commit()
     db.refresh(db_user)
     return db_user
+
+
+def get_users(db: Session, skip: int = 0, limit: int = 100):
+    """Retrieve multiple users."""
+    return (
+        db.query(models.User)
+        .options(joinedload(models.User.department))
+        .offset(skip)
+        .limit(limit)
+        .all()
+    )
 
 
 def search_users(db: Session, query: str, limit: int = 10):

--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -1,0 +1,48 @@
+from fastapi import Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordBearer
+from jose import JWTError, jwt
+from sqlalchemy.orm import Session
+
+from . import crud, schemas, auth
+from .database import SessionLocal
+
+
+def get_db():
+    """Yield a database session for the request."""
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
+
+
+async def get_current_user(token: str = Depends(oauth2_scheme), db: Session = Depends(get_db)):
+    """Retrieve the current user based on the access token."""
+    credentials_exception = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Could not validate credentials",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+    try:
+        payload = jwt.decode(token, auth.SECRET_KEY, algorithms=[auth.ALGORITHM])
+        employee_id: str | None = payload.get("sub")
+        if employee_id is None:
+            raise credentials_exception
+        token_data = schemas.TokenData(employee_id=employee_id)
+    except JWTError:
+        raise credentials_exception
+    user = crud.get_user_by_employee_id(db, employee_id=token_data.employee_id)
+    if user is None:
+        raise credentials_exception
+    return user
+
+
+async def require_admin(current_user: schemas.User = Depends(get_current_user)) -> schemas.User:
+    """Ensure the current user has admin privileges."""
+    if not getattr(current_user, "is_admin", False):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Admin privileges required")
+    return current_user
+

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -8,6 +8,7 @@ from jose import JWTError, jwt # JWTError, jwtをインポート
 # これまでに作成した各モジュールをインポート
 from . import crud, models, schemas, auth
 from .database import SessionLocal, engine, Base
+from .routers.admin import users as admin_users
 
 # Configure basic logging
 logging.basicConfig(
@@ -88,6 +89,7 @@ def on_startup():
             "name": "ﾃｽﾄｶﾝﾘｼｬ",
             "password": "admin",
             "department_id": 0,
+            "is_admin": True,
         },
     ]
 
@@ -98,6 +100,7 @@ def on_startup():
             normalized = schemas.UserUpdate(name=user_data["name"])
             user.name = normalized.name
             user.hashed_password = auth.get_password_hash(user_data["password"])
+            user.is_admin = user_data.get("is_admin", False)
             db.commit()
         else:
             user_in = schemas.UserCreate(**user_data)
@@ -191,3 +194,6 @@ def read_mentioned_posts(
     """Retrieve posts where the current user is mentioned."""
     posts = crud.get_posts_mentioned(db, user_id=current_user.id)
     return posts
+
+# include routers
+app.include_router(admin_users.router)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, DateTime, ForeignKey, Table
+from sqlalchemy import Column, Integer, String, DateTime, ForeignKey, Table, Boolean
 from sqlalchemy.orm import relationship
 from datetime import datetime, timezone
 
@@ -32,6 +32,7 @@ class User(Base):
     name = Column(String, default="名無しさん") # ニックネーム機能を見越してデフォルト値設定
     hashed_password = Column(String, nullable=False)
     department_id = Column(Integer, ForeignKey("departments.id"))
+    is_admin = Column(Boolean, default=False)
 
     department = relationship("Department", back_populates="users")
 

--- a/backend/app/routers/admin/users.py
+++ b/backend/app/routers/admin/users.py
@@ -1,0 +1,18 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from ... import models, schemas, crud
+from ...dependencies import get_db, require_admin
+
+
+router = APIRouter(prefix="/admin/users", tags=["admin"])
+
+
+@router.get("/", response_model=list[schemas.User])
+def list_users(
+    db: Session = Depends(get_db),
+    _: schemas.User = Depends(require_admin),
+):
+    """List all registered users."""
+    return crud.get_users(db)
+

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -47,6 +47,7 @@ class UserBase(BaseModel):
 # ユーザーを作成する際に受け取るデータ型（パスワードを含む）
 class UserCreate(UserBase):
     password: str
+    is_admin: bool = False
 
 
 class UserUpdate(BaseModel):
@@ -65,6 +66,7 @@ class UserUpdate(BaseModel):
 class User(UserBase):
     id: int
     department_name: Optional[str] = None
+    is_admin: bool = False
 
     class Config:
         from_attributes = True


### PR DESCRIPTION
## Summary
- expand models and schemas with `is_admin`
- add admin check dependency
- implement `/admin/users` endpoint
- include router in the main app

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852230ba9fc8323af390ea982cebf57