### PR TITLE
Add admin management features

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -9,6 +9,8 @@ from jose import JWTError, jwt # JWTError, jwtをインポート
 from . import crud, models, schemas, auth
 from .database import SessionLocal, engine, Base
 from .routers.admin import users as admin_users
+from .routers.admin import departments as admin_departments
+from .routers.admin import posts as admin_posts
 
 # Configure basic logging
 logging.basicConfig(
@@ -197,3 +199,5 @@ def read_mentioned_posts(
 
 # include routers
 app.include_router(admin_users.router)
+app.include_router(admin_departments.router)
+app.include_router(admin_posts.router)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -33,6 +33,7 @@ class User(Base):
     hashed_password = Column(String, nullable=False)
     department_id = Column(Integer, ForeignKey("departments.id"))
     is_admin = Column(Boolean, default=False)
+    is_active = Column(Boolean, default=True)
 
     department = relationship("Department", back_populates="users")
 

--- a/backend/app/routers/admin/departments.py
+++ b/backend/app/routers/admin/departments.py
@@ -1,0 +1,43 @@
+from fastapi import APIRouter, Depends, HTTPException, status, Response
+from sqlalchemy.orm import Session
+
+from ... import crud, schemas
+from ...dependencies import get_db, require_admin
+
+
+router = APIRouter(prefix="/admin/departments", tags=["admin"])
+
+
+@router.post("/", response_model=schemas.Department, status_code=status.HTTP_201_CREATED)
+def create_department(
+    department: schemas.DepartmentCreate,
+    db: Session = Depends(get_db),
+    _: schemas.User = Depends(require_admin),
+):
+    return crud.create_department(db, department)
+
+
+@router.put("/{dept_id}", response_model=schemas.Department)
+def update_department(
+    dept_id: int,
+    department: schemas.DepartmentCreate,
+    db: Session = Depends(get_db),
+    _: schemas.User = Depends(require_admin),
+):
+    updated = crud.update_department(db, dept_id, department)
+    if not updated:
+        raise HTTPException(status_code=404, detail="Department not found")
+    return updated
+
+
+@router.delete("/{dept_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_department(
+    dept_id: int,
+    db: Session = Depends(get_db),
+    _: schemas.User = Depends(require_admin),
+):
+    success = crud.delete_department(db, dept_id)
+    if not success:
+        raise HTTPException(status_code=404, detail="Department not found")
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+

--- a/backend/app/routers/admin/posts.py
+++ b/backend/app/routers/admin/posts.py
@@ -1,0 +1,41 @@
+from fastapi import APIRouter, Depends, HTTPException, status, Response
+from sqlalchemy.orm import Session
+
+from ... import crud, schemas
+from ...dependencies import get_db, require_admin
+
+
+router = APIRouter(prefix="/admin/posts", tags=["admin"])
+
+
+@router.get("/", response_model=list[schemas.AdminPost])
+def list_posts(
+    db: Session = Depends(get_db),
+    _: schemas.User = Depends(require_admin),
+):
+    posts = crud.get_all_posts(db)
+    result = []
+    for p in posts:
+        result.append(
+            schemas.AdminPost(
+                id=p.id,
+                content=p.content,
+                created_at=p.created_at,
+                author_name=p.author.name if p.author else None,
+                department_name=p.author.department.name if p.author and p.author.department else None,
+            )
+        )
+    return result
+
+
+@router.delete("/{post_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_post(
+    post_id: int,
+    db: Session = Depends(get_db),
+    _: schemas.User = Depends(require_admin),
+):
+    success = crud.delete_post(db, post_id)
+    if not success:
+        raise HTTPException(status_code=404, detail="Post not found")
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+

--- a/backend/app/routers/admin/users.py
+++ b/backend/app/routers/admin/users.py
@@ -1,5 +1,6 @@
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
+from fastapi import HTTPException, status, Response
 
 from ... import models, schemas, crud
 from ...dependencies import get_db, require_admin
@@ -15,4 +16,17 @@ def list_users(
 ):
     """List all registered users."""
     return crud.get_users(db)
+
+
+@router.delete("/{user_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_user(
+    user_id: int,
+    db: Session = Depends(get_db),
+    _: schemas.User = Depends(require_admin),
+):
+    """Deactivate a user account."""
+    success = crud.deactivate_user(db, user_id)
+    if not success:
+        raise HTTPException(status_code=404, detail="User not found")
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -67,6 +67,7 @@ class User(UserBase):
     id: int
     department_name: Optional[str] = None
     is_admin: bool = False
+    is_active: bool = True
 
     class Config:
         from_attributes = True
@@ -77,6 +78,36 @@ class UserSearchResult(BaseModel):
 
     id: int
     name: str
+    department_name: Optional[str] = None
+
+    class Config:
+        from_attributes = True
+
+
+# --- Department Schemas ---
+
+class DepartmentBase(BaseModel):
+    name: str
+
+
+class DepartmentCreate(DepartmentBase):
+    pass
+
+
+class Department(DepartmentBase):
+    id: int
+
+    class Config:
+        from_attributes = True
+
+
+# --- Admin Post Schema ---
+
+class AdminPost(BaseModel):
+    id: int
+    content: str
+    created_at: datetime
+    author_name: str
     department_name: Optional[str] = None
 
     class Config:

--- a/backend/app/tests/test_admin.py
+++ b/backend/app/tests/test_admin.py
@@ -1,0 +1,59 @@
+from fastapi.testclient import TestClient
+from ..main import app
+from ..database import SessionLocal
+from .. import crud, schemas, models
+import uuid
+
+
+def _get_admin_token(client: TestClient) -> str:
+    resp = client.post("/token", data={"username": "999999", "password": "admin"})
+    assert resp.status_code == 200
+    return resp.json()["access_token"]
+
+
+def test_admin_delete_user():
+    with TestClient(app) as client:
+        token = _get_admin_token(client)
+        db = SessionLocal()
+        unique_emp_id = "deluser" + str(uuid.uuid4())[:8]
+        new_user = crud.create_user(
+            db,
+            schemas.UserCreate(
+                employee_id=unique_emp_id,
+                name="Delete User",
+                password="pass",
+                department_id=2,
+            ),
+        )
+        db.close()
+
+        resp = client.delete(f"/admin/users/{new_user.id}", headers={"Authorization": f"Bearer {token}"})
+        assert resp.status_code == 204
+
+        db = SessionLocal()
+        user = db.query(models.User).get(new_user.id)
+        assert user.is_active is False
+        db.close()
+
+
+def test_admin_list_and_delete_posts():
+    with TestClient(app) as client:
+        token = _get_admin_token(client)
+        db = SessionLocal()
+        user = crud.get_user_by_employee_id(db, "000000")
+        p1 = crud.create_post(db, schemas.PostCreate(content="admin post 1"), user.id)
+        p2 = crud.create_post(db, schemas.PostCreate(content="admin post 2"), user.id)
+        p1_id = p1.id
+        db.close()
+
+        resp = client.get("/admin/posts", headers={"Authorization": f"Bearer {token}"})
+        assert resp.status_code == 200
+        posts = resp.json()
+        assert posts[0]["created_at"] >= posts[1]["created_at"]
+
+        del_resp = client.delete(f"/admin/posts/{p1_id}", headers={"Authorization": f"Bearer {token}"})
+        assert del_resp.status_code == 204
+
+        db = SessionLocal()
+        assert db.query(models.Post).get(p1_id) is None
+        db.close()


### PR DESCRIPTION
## Summary
- allow admins to soft-delete users
- implement CRUD for departments
- implement admin post listing and deletion
- expose `is_active` flag and department/post admin schemas
- mount new routers
- add tests for new admin endpoints

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68522614ff048323acdb0933d4b27db0