### PR TITLE
Implement post reporting system

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -11,6 +11,7 @@ from .database import SessionLocal, engine, Base
 from .routers.admin import users as admin_users
 from .routers.admin import departments as admin_departments
 from .routers.admin import posts as admin_posts
+from .routers.admin import reports as admin_reports
 
 # Configure basic logging
 logging.basicConfig(
@@ -197,7 +198,26 @@ def read_mentioned_posts(
     posts = crud.get_posts_mentioned(db, user_id=current_user.id)
     return posts
 
+
+@app.post("/reports", response_model=schemas.ReportOut, status_code=status.HTTP_201_CREATED)
+def create_report(
+    report: schemas.ReportCreate,
+    db: Session = Depends(get_db),
+    current_user: schemas.User = Depends(get_current_user),
+):
+    created = crud.create_report(db, report, reporter_id=current_user.id)
+    return schemas.ReportOut(
+        id=created.id,
+        reported_post_id=created.reported_post_id,
+        reporter_user_id=created.reporter_user_id,
+        reason=created.reason,
+        reported_at=created.reported_at,
+        reporter_name=created.reporter.name if created.reporter else None,
+        post_content=created.reported_post.content if created.reported_post else None,
+    )
+
 # include routers
 app.include_router(admin_users.router)
 app.include_router(admin_departments.router)
 app.include_router(admin_posts.router)
+app.include_router(admin_reports.router)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -79,3 +79,19 @@ class Post(Base):
     @property
     def mention_user_ids(self) -> list[int]:
         return [user.id for user in self.mentions]
+
+
+class Report(Base):
+    __tablename__ = "reports"
+
+    id = Column(Integer, primary_key=True, index=True)
+    reported_post_id = Column(Integer, ForeignKey("posts.id"), nullable=False)
+    reporter_user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    reason = Column(String(255))
+    reported_at = Column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+    )
+
+    reported_post = relationship("Post")
+    reporter = relationship("User")

--- a/backend/app/routers/admin/reports.py
+++ b/backend/app/routers/admin/reports.py
@@ -1,0 +1,29 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from ... import crud, schemas
+from ...dependencies import get_db, require_admin
+
+router = APIRouter(prefix="/admin/reports", tags=["admin"])
+
+
+@router.get("/", response_model=list[schemas.ReportOut])
+def list_reports(
+    db: Session = Depends(get_db),
+    _: schemas.User = Depends(require_admin),
+):
+    reports = crud.get_reports(db)
+    result = []
+    for r in reports:
+        result.append(
+            schemas.ReportOut(
+                id=r.id,
+                reported_post_id=r.reported_post_id,
+                reporter_user_id=r.reporter_user_id,
+                reason=r.reason,
+                reported_at=r.reported_at,
+                reporter_name=r.reporter.name if r.reporter else None,
+                post_content=r.reported_post.content if r.reported_post else None,
+            )
+        )
+    return result

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -125,3 +125,23 @@ class Token(BaseModel):
 # トークンをデコードした後のデータ（ペイロード）の型
 class TokenData(BaseModel):
     employee_id: Optional[str] = None
+
+
+# --- Report Schemas ---
+
+class ReportCreate(BaseModel):
+    reported_post_id: int
+    reason: constr(max_length=255)
+
+
+class ReportOut(BaseModel):
+    id: int
+    reported_post_id: int
+    reporter_user_id: int
+    reason: str
+    reported_at: datetime
+    reporter_name: Optional[str] = None
+    post_content: Optional[str] = None
+
+    class Config:
+        from_attributes = True

--- a/backend/app/tests/test_reports.py
+++ b/backend/app/tests/test_reports.py
@@ -1,0 +1,34 @@
+from fastapi.testclient import TestClient
+from ..main import app
+from .test_admin import _get_admin_token
+
+
+def _get_token(client: TestClient, username: str, password: str) -> str:
+    resp = client.post("/token", data={"username": username, "password": password})
+    assert resp.status_code == 200
+    return resp.json()["access_token"]
+
+
+def test_report_flow():
+    with TestClient(app) as client:
+        # user1 creates a post
+        token_user1 = _get_token(client, "000001", "000001")
+        headers_user1 = {"Authorization": f"Bearer {token_user1}"}
+        post_resp = client.post("/posts/", json={"content": "report target"}, headers=headers_user1)
+        assert post_resp.status_code == 201
+        post_id = post_resp.json()["id"]
+
+        # user2 reports the post
+        token_user2 = _get_token(client, "000002", "000002")
+        headers_user2 = {"Authorization": f"Bearer {token_user2}"}
+        report_resp = client.post("/reports", json={"reported_post_id": post_id, "reason": "spam"}, headers=headers_user2)
+        assert report_resp.status_code == 201
+        report_id = report_resp.json()["id"]
+
+        # admin retrieves reports
+        admin_token = _get_admin_token(client)
+        headers_admin = {"Authorization": f"Bearer {admin_token}"}
+        list_resp = client.get("/admin/reports", headers=headers_admin)
+        assert list_resp.status_code == 200
+        reports = list_resp.json()
+        assert any(r["id"] == report_id and r["post_content"] == "report target" for r in reports)


### PR DESCRIPTION
## Summary
- create new `Report` model
- add `ReportCreate` and `ReportOut` schemas
- implement CRUD helpers for reports
- expose `/reports` POST endpoint
- add admin reports API and router
- test reporting flow

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68526ced271c8323baeda617aa4f198f