### PR TITLE
Add post reporting modal

### DIFF
--- a/frontend/src/components/ui/PostCard.tsx
+++ b/frontend/src/components/ui/PostCard.tsx
@@ -1,0 +1,66 @@
+import React, { useState } from 'react';
+
+interface Post {
+  id: number;
+  content: string;
+  created_at: string;
+}
+
+type PostCardProps = {
+  post: Post;
+  onReport: (post: Post) => void;
+};
+
+const formatRelativeTime = (isoString: string): string => {
+  const now = new Date();
+  const past = new Date(isoString);
+  const diffInSeconds = Math.floor((now.getTime() - past.getTime()) / 1000);
+
+  const minutes = Math.floor(diffInSeconds / 60);
+  if (minutes < 1) return 'たった今';
+  if (minutes < 60) return `${minutes}分前`;
+
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}時間前`;
+
+  const days = Math.floor(hours / 24);
+  return `${days}日前`;
+};
+
+const PostCard: React.FC<PostCardProps> = ({ post, onReport }) => {
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  return (
+    <div className="p-4 border-b border-gray-200 hover:bg-gray-50 relative">
+      <div className="flex justify-between items-center mb-2">
+        <span className="text-sm text-gray-500">
+          {formatRelativeTime(post.created_at)}
+        </span>
+        <div className="relative">
+          <button
+            onClick={() => setMenuOpen((o) => !o)}
+            className="px-2 text-gray-500 hover:text-gray-700"
+          >
+            &#8230;
+          </button>
+          {menuOpen && (
+            <div className="absolute right-0 mt-2 w-40 bg-white border border-gray-300 rounded shadow-md z-10">
+              <button
+                className="w-full text-left px-4 py-2 text-sm hover:bg-gray-100"
+                onClick={() => {
+                  setMenuOpen(false);
+                  onReport(post);
+                }}
+              >
+                Report this post
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+      <p className="text-gray-800 whitespace-pre-wrap">{post.content}</p>
+    </div>
+  );
+};
+
+export default PostCard;

--- a/frontend/src/components/ui/ReportModal.tsx
+++ b/frontend/src/components/ui/ReportModal.tsx
@@ -1,0 +1,103 @@
+import React, { useState } from 'react';
+import apiClient from '../../services/api';
+
+interface Post {
+  id: number;
+  content: string;
+}
+
+type ReportModalProps = {
+  post: Post;
+  onClose: () => void;
+};
+
+const MAX_CHARS = 255;
+
+const ReportModal: React.FC<ReportModalProps> = ({ post, onClose }) => {
+  const [reason, setReason] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState('');
+
+  const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    if (e.target.value.length <= MAX_CHARS) {
+      setReason(e.target.value);
+    }
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!reason.trim()) {
+      setError('理由を入力してください');
+      return;
+    }
+    setIsSubmitting(true);
+    setError('');
+    try {
+      await apiClient.post('/reports', {
+        reported_post_id: post.id,
+        reason,
+      });
+      alert('報告を送信しました');
+      onClose();
+    } catch (err) {
+      setError('報告に失敗しました');
+      console.error(err);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-center z-50"
+      onClick={onClose}
+    >
+      <div
+        className="bg-white rounded-lg shadow-xl w-full max-w-lg p-6"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex justify-between items-center border-b pb-3 mb-4">
+          <h2 className="text-xl font-bold">報告する</h2>
+          <button onClick={onClose} className="text-gray-500 hover:text-gray-800">
+            &times;
+          </button>
+        </div>
+        <div className="mb-4 p-3 bg-gray-100 rounded text-sm whitespace-pre-wrap">
+          {post.content}
+        </div>
+        <form onSubmit={handleSubmit}>
+          <textarea
+            value={reason}
+            onChange={handleChange}
+            className="w-full h-32 p-3 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+            placeholder="報告理由を入力してください"
+            autoFocus
+          />
+          <div className="flex justify-between items-center mt-2">
+            <p className={`text-sm ${reason.length === MAX_CHARS ? 'text-red-500' : 'text-gray-500'}`}> {reason.length} / {MAX_CHARS}</p>
+            {error && <p className="text-red-500 text-sm">{error}</p>}
+          </div>
+          <div className="flex justify-end mt-4">
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-4 py-2 mr-2 text-gray-700 bg-gray-200 rounded-md hover:bg-gray-300"
+              disabled={isSubmitting}
+            >
+              キャンセル
+            </button>
+            <button
+              type="submit"
+              className="px-4 py-2 text-white bg-blue-600 rounded-md hover:bg-blue-700 disabled:bg-blue-300"
+              disabled={isSubmitting || !reason.trim()}
+            >
+              {isSubmitting ? '送信中...' : '送信'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default ReportModal;

--- a/frontend/src/components/ui/Timeline.tsx
+++ b/frontend/src/components/ui/Timeline.tsx
@@ -1,5 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import apiClient from '../../services/api';
+import PostCard from './PostCard';
+import ReportModal from './ReportModal';
 
 // 投稿データの型を定義
 interface Post {
@@ -36,6 +38,7 @@ const Timeline: React.FC<TimelineProps> = ({ postSuccessTrigger, endpoint }) => 
   const [posts, setPosts] = useState<Post[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [reportPost, setReportPost] = useState<Post | null>(null);
 
   useEffect(() => {
     const fetchPosts = async () => {
@@ -71,15 +74,11 @@ const Timeline: React.FC<TimelineProps> = ({ postSuccessTrigger, endpoint }) => 
   return (
     <div>
       {posts.map((post) => (
-        <div key={post.id} className="p-4 border-b border-gray-200 hover:bg-gray-50">
-          <div className="flex justify-between items-center mb-2">
-            <span className="text-sm text-gray-500">
-              {formatRelativeTime(post.created_at)}
-            </span>
-          </div>
-          <p className="text-gray-800 whitespace-pre-wrap">{post.content}</p>
-        </div>
+        <PostCard key={post.id} post={post} onReport={(p) => setReportPost(p)} />
       ))}
+      {reportPost && (
+        <ReportModal post={reportPost} onClose={() => setReportPost(null)} />
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add `PostCard` component with 3-dot menu
- add `ReportModal` component to submit reports
- update `Timeline` to open the modal and call API

## Testing
- `pytest backend/app/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_685275d0138c8323818649973b9e9505