### PR TITLE
Implement report status and soft deletion

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -214,6 +214,7 @@ def create_report(
         reported_at=created.reported_at,
         reporter_name=created.reporter.name if created.reporter else None,
         post_content=created.reported_post.content if created.reported_post else None,
+        status=created.status.value,
     )
 
 # include routers

--- a/backend/app/routers/admin/posts.py
+++ b/backend/app/routers/admin/posts.py
@@ -16,6 +16,14 @@ def list_posts(
     posts = crud.get_all_posts(db)
     result = []
     for p in posts:
+        reports = [
+            schemas.ReportForPost(
+                reporter_name=r.reporter.name if r.reporter else None,
+                reason=r.reason,
+                status=r.status.value,
+            )
+            for r in p.reports
+        ]
         result.append(
             schemas.AdminPost(
                 id=p.id,
@@ -24,6 +32,37 @@ def list_posts(
                 author_name=p.author.name if p.author else None,
                 department_name=p.author.department.name if p.author and p.author.department else None,
                 mention_user_ids=p.mention_user_ids,
+                reports=reports,
+            )
+        )
+    return result
+
+
+@router.get("/deleted", response_model=list[schemas.AdminPost])
+def list_deleted_posts(
+    db: Session = Depends(get_db),
+    _: schemas.User = Depends(require_admin),
+):
+    posts = crud.get_deleted_posts(db)
+    result = []
+    for p in posts:
+        reports = [
+            schemas.ReportForPost(
+                reporter_name=r.reporter.name if r.reporter else None,
+                reason=r.reason,
+                status=r.status.value,
+            )
+            for r in p.reports
+        ]
+        result.append(
+            schemas.AdminPost(
+                id=p.id,
+                content=p.content,
+                created_at=p.created_at,
+                author_name=p.author.name if p.author else None,
+                department_name=p.author.department.name if p.author and p.author.department else None,
+                mention_user_ids=p.mention_user_ids,
+                reports=reports,
             )
         )
     return result

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,4 +1,5 @@
 from pydantic import BaseModel, constr, field_validator
+from enum import Enum
 import jaconv
 from datetime import datetime
 from typing import Optional
@@ -110,6 +111,7 @@ class AdminPost(BaseModel):
     author_name: str
     department_name: Optional[str] = None
     mention_user_ids: list[int] = []
+    reports: list['ReportForPost'] = []
 
     class Config:
         from_attributes = True
@@ -129,6 +131,11 @@ class TokenData(BaseModel):
 
 # --- Report Schemas ---
 
+class ReportStatus(str, Enum):
+    pending = "pending"
+    deleted = "deleted"
+    ignored = "ignored"
+
 class ReportCreate(BaseModel):
     reported_post_id: int
     reason: constr(max_length=255)
@@ -142,6 +149,7 @@ class ReportOut(BaseModel):
     reported_at: datetime
     reporter_name: Optional[str] = None
     post_content: Optional[str] = None
+    status: ReportStatus
 
     class Config:
         from_attributes = True
@@ -158,6 +166,20 @@ class AdminReport(BaseModel):
     post_author_id: Optional[int] = None
     post_author_name: Optional[str] = None
     post_created_at: Optional[datetime] = None
+    status: ReportStatus
+
+    class Config:
+        from_attributes = True
+
+
+class ReportStatusUpdate(BaseModel):
+    status: ReportStatus
+
+
+class ReportForPost(BaseModel):
+    reporter_name: Optional[str] = None
+    reason: str
+    status: ReportStatus
 
     class Config:
         from_attributes = True


### PR DESCRIPTION
## Summary
- add `Status` enum and soft-delete flag to models
- filter posts by `is_deleted`
- allow admins to update report status and see deleted posts
- expose reports in admin post responses
- extend schemas and adjust tests

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853663f288c83239e9c030be1dc06b5