### PR TITLE
Add admin post moderation UI

### DIFF
--- a/frontend/src/components/admin/PostAdminPanel.tsx
+++ b/frontend/src/components/admin/PostAdminPanel.tsx
@@ -1,9 +1,136 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import apiClient from '../../services/api';
+import ReportCard, { Report } from './ReportCard';
 
-const PostAdminPanel: React.FC = () => {
+interface AdminPost {
+  id: number;
+  content: string;
+  created_at: string;
+  author_name: string;
+  department_name?: string | null;
+  mention_user_ids: number[];
+  reports: Report[];
+}
+
+type Props = {
+  showDeleted?: boolean;
+};
+
+const PostAdminPanel: React.FC<Props> = ({ showDeleted }) => {
+  const [posts, setPosts] = useState<AdminPost[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [expanded, setExpanded] = useState<Record<number, boolean>>({});
+
+  const endpoint = showDeleted ? '/admin/posts/deleted' : '/admin/posts';
+
+  const fetchData = async () => {
+    try {
+      setLoading(true);
+      const [postResp, reportResp] = await Promise.all([
+        apiClient.get<AdminPost[]>(endpoint),
+        apiClient.get<any[]>('/admin/reports'),
+      ]);
+      const reportsByPost: Record<number, Report[]> = {};
+      reportResp.data.forEach((r: any) => {
+        if (!reportsByPost[r.reported_post_id]) reportsByPost[r.reported_post_id] = [];
+        reportsByPost[r.reported_post_id].push({
+          id: r.id,
+          reporter_name: r.reporter_name,
+          reason: r.reason,
+          status: r.status,
+        });
+      });
+      const combined = postResp.data.map((p: any) => ({
+        ...p,
+        reports: reportsByPost[p.id] || [],
+      }));
+      setPosts(combined);
+      setError(null);
+    } catch (err) {
+      console.error(err);
+      setError('投稿一覧の取得に失敗しました。');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchData();
+  }, [showDeleted]);
+
+  const updateStatus = async (
+    reportId: number,
+    status: 'deleted' | 'ignored',
+    postId: number,
+  ) => {
+    const confirmMsg =
+      status === 'deleted' ? 'この投稿を削除しますか?' : 'この報告を無視しますか?';
+    if (!window.confirm(confirmMsg)) return;
+    try {
+      await apiClient.patch(`/admin/reports/${reportId}`, { status });
+      setPosts((prev) => {
+        let next = prev.map((p) => {
+          if (p.id !== postId) return p;
+          const updatedReports = p.reports.map((r) =>
+            r.id === reportId ? { ...r, status } : r,
+          );
+          return { ...p, reports: updatedReports };
+        });
+        if (status === 'deleted' && !showDeleted) {
+          next = next.filter((p) => p.id !== postId);
+        }
+        return next;
+      });
+    } catch (err) {
+      console.error(err);
+      alert('ステータスの更新に失敗しました');
+    }
+  };
+
+  if (loading) return <div className="p-4 text-gray-500">読み込み中...</div>;
+  if (error) return <div className="p-4 text-red-500">{error}</div>;
+  if (posts.length === 0) return <div className="p-4 text-gray-500">投稿がありません。</div>;
+
   return (
-    <div className="p-4">
-      <p>Post Management Placeholder</p>
+    <div className="p-4 space-y-4">
+      {posts.map((post) => (
+        <div key={post.id} className="border rounded p-4">
+          <div className="text-sm text-gray-600 flex justify-between mb-2">
+            <span>{new Date(post.created_at).toLocaleString()}</span>
+            <span>
+              {post.author_name}
+              {post.department_name ? ` / ${post.department_name}` : ''}
+            </span>
+          </div>
+          <p className="whitespace-pre-wrap mb-2">{post.content}</p>
+          {post.reports.length === 0 ? (
+            <p className="text-sm text-gray-500">No reports</p>
+          ) : (
+            <div>
+              {(expanded[post.id] ? post.reports : [post.reports[0]]).map((r) => (
+                <ReportCard
+                  key={r.id}
+                  report={r}
+                  readOnly={showDeleted}
+                  onDelete={() => updateStatus(r.id, 'deleted', post.id)}
+                  onIgnore={() => updateStatus(r.id, 'ignored', post.id)}
+                />
+              ))}
+              {post.reports.length > 1 && (
+                <button
+                  className="mt-1 text-xs text-blue-600 hover:underline"
+                  onClick={() =>
+                    setExpanded((e) => ({ ...e, [post.id]: !e[post.id] }))
+                  }
+                >
+                  {expanded[post.id] ? 'Hide reports' : 'Show all reports'}
+                </button>
+              )}
+            </div>
+          )}
+        </div>
+      ))}
     </div>
   );
 };

--- a/frontend/src/components/admin/ReportCard.tsx
+++ b/frontend/src/components/admin/ReportCard.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+
+export interface Report {
+  id: number;
+  reporter_name?: string | null;
+  reason: string;
+  status: 'pending' | 'deleted' | 'ignored';
+}
+
+type Props = {
+  report: Report;
+  onDelete?: () => void;
+  onIgnore?: () => void;
+  readOnly?: boolean;
+};
+
+const badgeClass = (status: string) => {
+  const base = 'px-2 py-0.5 rounded text-xs';
+  switch (status) {
+    case 'deleted':
+      return `${base} bg-red-100 text-red-800`;
+    case 'ignored':
+      return `${base} bg-blue-100 text-blue-800`;
+    default:
+      return `${base} bg-gray-100 text-gray-800`;
+  }
+};
+
+const ReportCard: React.FC<Props> = ({ report, onDelete, onIgnore, readOnly }) => {
+  return (
+    <div className="border-t pt-2 text-sm space-y-1">
+      <div className="flex justify-between items-center">
+        <div>
+          {report.reporter_name ?? 'Unknown'}: {report.reason}
+        </div>
+        <span className={badgeClass(report.status)}>{report.status}</span>
+      </div>
+      {report.status === 'pending' && !readOnly && (
+        <div className="space-x-2">
+          <button
+            className="text-red-600 hover:underline"
+            onClick={onDelete}
+          >
+            Delete post
+          </button>
+          <button
+            className="text-gray-600 hover:underline"
+            onClick={onIgnore}
+          >
+            Ignore
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ReportCard;

--- a/frontend/src/pages/AdminDashboard.tsx
+++ b/frontend/src/pages/AdminDashboard.tsx
@@ -5,7 +5,9 @@ import PostAdminPanel from '../components/admin/PostAdminPanel';
 import ReportAdminPanel from '../components/admin/ReportAdminPanel';
 
 const AdminDashboard: React.FC = () => {
-  const [activeTab, setActiveTab] = useState<'users' | 'departments' | 'posts' | 'reports'>('users');
+  const [activeTab, setActiveTab] = useState<
+    'users' | 'departments' | 'posts' | 'deletedPosts' | 'reports'
+  >('users');
 
   const renderActivePanel = () => {
     switch (activeTab) {
@@ -13,6 +15,8 @@ const AdminDashboard: React.FC = () => {
         return <DepartmentAdminPanel />;
       case 'posts':
         return <PostAdminPanel />;
+      case 'deletedPosts':
+        return <PostAdminPanel showDeleted />;
       case 'reports':
         return <ReportAdminPanel />;
       case 'users':
@@ -55,6 +59,16 @@ const AdminDashboard: React.FC = () => {
             }`}
           >
             Posts
+          </button>
+          <button
+            onClick={() => setActiveTab('deletedPosts')}
+            className={`py-2 px-4 font-semibold focus:outline-none ${
+              activeTab === 'deletedPosts'
+                ? 'border-b-2 border-blue-500 text-blue-600'
+                : 'text-gray-500'
+            }`}
+          >
+            Deleted Posts
           </button>
           <button
             onClick={() => setActiveTab('reports')}


### PR DESCRIPTION
## Summary
- implement `ReportCard` for displaying individual reports
- expand `PostAdminPanel` to view post reports and update their status
- add Deleted Posts tab to admin dashboard

## Testing
- `npm run lint` *(fails: ESLint config issue)*
- `pytest` *(fails: ModuleNotFoundError: fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_6853695601ec8323af45e8e6202ecead