### PR TITLE
Unify posts into reports panel

### DIFF
--- a/frontend/src/components/admin/PostAdminPanel.tsx
+++ b/frontend/src/components/admin/PostAdminPanel.tsx
@@ -98,24 +98,32 @@ const PostAdminPanel: React.FC<Props> = ({ showDeleted }) => {
         <div key={post.id} className="border rounded p-4">
           <div className="text-sm text-gray-600 flex justify-between mb-2">
             <span>{new Date(post.created_at).toLocaleString()}</span>
-            <span>
-              {post.author_name}
-              {post.department_name ? ` / ${post.department_name}` : ''}
+            <span className="flex items-center space-x-1">
+              <span>
+                {post.author_name}
+                {post.department_name ? ` / ${post.department_name}` : ''}
+              </span>
+              {post.reports.length > 0 ? (
+                <span className="px-2 py-0.5 rounded bg-red-100 text-red-800 text-xs">Reported</span>
+              ) : (
+                <span className="px-2 py-0.5 rounded bg-gray-100 text-gray-600 text-xs">Unreported</span>
+              )}
             </span>
           </div>
           <p className="whitespace-pre-wrap mb-2">{post.content}</p>
           {post.reports.length === 0 ? (
-            <p className="text-sm text-gray-500">No reports</p>
+            <p className="text-sm text-gray-500">No reports submitted</p>
           ) : (
             <div>
               {(expanded[post.id] ? post.reports : [post.reports[0]]).map((r) => (
-                <ReportCard
-                  key={r.id}
-                  report={r}
-                  readOnly={showDeleted}
-                  onDelete={() => updateStatus(r.id, 'deleted', post.id)}
-                  onIgnore={() => updateStatus(r.id, 'ignored', post.id)}
-                />
+                <div className="bg-gray-50 p-2 rounded mb-1" key={r.id}>
+                  <ReportCard
+                    report={r}
+                    readOnly={showDeleted}
+                    onDelete={() => updateStatus(r.id, 'deleted', post.id)}
+                    onIgnore={() => updateStatus(r.id, 'ignored', post.id)}
+                  />
+                </div>
               ))}
               {post.reports.length > 1 && (
                 <button

--- a/frontend/src/components/admin/ReportCard.tsx
+++ b/frontend/src/components/admin/ReportCard.tsx
@@ -28,7 +28,7 @@ const badgeClass = (status: string) => {
 
 const ReportCard: React.FC<Props> = ({ report, onDelete, onIgnore, readOnly }) => {
   return (
-    <div className="border-t pt-2 text-sm space-y-1">
+    <div className="text-sm space-y-1">
       <div className="flex justify-between items-center">
         <div>
           {report.reporter_name ?? 'Unknown'}: {report.reason}

--- a/frontend/src/pages/AdminDashboard.tsx
+++ b/frontend/src/pages/AdminDashboard.tsx
@@ -2,23 +2,20 @@ import React, { useState } from 'react';
 import UserAdminPanel from '../components/admin/UserAdminPanel';
 import DepartmentAdminPanel from '../components/admin/DepartmentAdminPanel';
 import PostAdminPanel from '../components/admin/PostAdminPanel';
-import ReportAdminPanel from '../components/admin/ReportAdminPanel';
 
 const AdminDashboard: React.FC = () => {
   const [activeTab, setActiveTab] = useState<
-    'users' | 'departments' | 'posts' | 'deletedPosts' | 'reports'
+    'users' | 'departments' | 'deletedPosts' | 'reports'
   >('users');
 
   const renderActivePanel = () => {
     switch (activeTab) {
       case 'departments':
         return <DepartmentAdminPanel />;
-      case 'posts':
-        return <PostAdminPanel />;
       case 'deletedPosts':
         return <PostAdminPanel showDeleted />;
       case 'reports':
-        return <ReportAdminPanel />;
+        return <PostAdminPanel />;
       case 'users':
       default:
         return <UserAdminPanel />;
@@ -49,16 +46,6 @@ const AdminDashboard: React.FC = () => {
             }`}
           >
             Departments
-          </button>
-          <button
-            onClick={() => setActiveTab('posts')}
-            className={`py-2 px-4 font-semibold focus:outline-none ${
-              activeTab === 'posts'
-                ? 'border-b-2 border-blue-500 text-blue-600'
-                : 'text-gray-500'
-            }`}
-          >
-            Posts
           </button>
           <button
             onClick={() => setActiveTab('deletedPosts')}


### PR DESCRIPTION
## Summary
- simplify admin tabs by removing Posts panel
- show posts in the Reports tab using `PostAdminPanel`
- indicate reported status with badges and style reports
- tweak report component styling

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853701ec43c8323949d9a4bb458602a