### PR TITLE
Update report moderation flow

### DIFF
--- a/backend/app/crud.py
+++ b/backend/app/crud.py
@@ -239,14 +239,18 @@ def get_reports(db: Session):
     return reports
 
 
-def update_report_status(db: Session, report_id: int, status: models.Report.Status):
+def update_report_status(db: Session, report_id: int, status: models.ReportStatus):
     report = db.query(models.Report).filter(models.Report.id == report_id).first()
     if not report:
         return None
     logger.info("Updating report %s status to %s", report_id, status.value)
-    report.status = status
-    if status == models.Report.Status.deleted and report.reported_post:
-        report.reported_post.is_deleted = True
+    post = report.reported_post
+    if post:
+        post.report_status = status
+        if status == models.ReportStatus.deleted:
+            post.is_deleted = True
+        elif status == models.ReportStatus.pending:
+            post.is_deleted = False
     db.commit()
     db.refresh(report)
     return report

--- a/backend/app/routers/admin/posts.py
+++ b/backend/app/routers/admin/posts.py
@@ -33,6 +33,7 @@ def list_posts(
                 department_name=p.author.department.name if p.author and p.author.department else None,
                 mention_user_ids=p.mention_user_ids,
                 reports=reports,
+                status=p.report_status,
             )
         )
     return result
@@ -63,6 +64,7 @@ def list_deleted_posts(
                 department_name=p.author.department.name if p.author and p.author.department else None,
                 mention_user_ids=p.mention_user_ids,
                 reports=reports,
+                status=p.report_status,
             )
         )
     return result

--- a/backend/app/routers/admin/reports.py
+++ b/backend/app/routers/admin/reports.py
@@ -48,7 +48,7 @@ def update_report(
     db: Session = Depends(get_db),
     _: schemas.User = Depends(require_admin),
 ):
-    updated = crud.update_report_status(db, report_id, models.Report.Status(body.status))
+    updated = crud.update_report_status(db, report_id, models.ReportStatus(body.status))
     if not updated:
         raise HTTPException(status_code=404, detail="Report not found")
     return schemas.AdminReport(

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -102,6 +102,13 @@ class Department(DepartmentBase):
         from_attributes = True
 
 
+# --- Report Schemas ---
+
+class ReportStatus(str, Enum):
+    pending = "pending"
+    deleted = "deleted"
+    ignored = "ignored"
+
 # --- Admin Post Schema ---
 
 class AdminPost(BaseModel):
@@ -112,6 +119,7 @@ class AdminPost(BaseModel):
     department_name: Optional[str] = None
     mention_user_ids: list[int] = []
     reports: list['ReportForPost'] = []
+    status: ReportStatus
 
     class Config:
         from_attributes = True
@@ -130,11 +138,6 @@ class TokenData(BaseModel):
 
 
 # --- Report Schemas ---
-
-class ReportStatus(str, Enum):
-    pending = "pending"
-    deleted = "deleted"
-    ignored = "ignored"
 
 class ReportCreate(BaseModel):
     reported_post_id: int

--- a/frontend/src/components/admin/ReportCard.tsx
+++ b/frontend/src/components/admin/ReportCard.tsx
@@ -9,9 +9,6 @@ export interface Report {
 
 type Props = {
   report: Report;
-  onDelete?: () => void;
-  onIgnore?: () => void;
-  readOnly?: boolean;
 };
 
 const badgeClass = (status: string) => {
@@ -28,7 +25,7 @@ const badgeClass = (status: string) => {
   }
 };
 
-const ReportCard: React.FC<Props> = ({ report, onDelete, onIgnore, readOnly }) => {
+const ReportCard: React.FC<Props> = ({ report }) => {
   return (
     <div className="text-sm space-y-1">
       <div className="flex justify-between items-start">
@@ -38,24 +35,8 @@ const ReportCard: React.FC<Props> = ({ report, onDelete, onIgnore, readOnly }) =
           </span>{' '}
           {report.reason}
         </div>
-        <span className={badgeClass(report.status)}>{report.status}</span>
       </div>
-      {report.status === 'pending' && !readOnly && (
-        <div className="space-x-2">
-          <button
-            className="text-red-600 hover:underline"
-            onClick={onDelete}
-          >
-            Delete post
-          </button>
-          <button
-            className="text-gray-600 hover:underline"
-            onClick={onIgnore}
-          >
-            Ignore
-          </button>
-        </div>
-      )}
+      {/* actions removed - status handled at post level */}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- keep deleted posts visible for admins
- store report status on posts and update backend logic
- include post moderation status in admin post API
- adjust admin UI with a status dropdown and shared badges

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685378cb63988323be02f9a110fecc1e