### PR TITLE
Fix report moderation missing IDs

### DIFF
--- a/backend/app/routers/admin/posts.py
+++ b/backend/app/routers/admin/posts.py
@@ -18,6 +18,7 @@ def list_posts(
     for p in posts:
         reports = [
             schemas.ReportForPost(
+                id=r.id,
                 reporter_name=r.reporter.name if r.reporter else None,
                 reason=r.reason,
                 status=r.status.value,
@@ -49,6 +50,7 @@ def list_deleted_posts(
     for p in posts:
         reports = [
             schemas.ReportForPost(
+                id=r.id,
                 reporter_name=r.reporter.name if r.reporter else None,
                 reason=r.reason,
                 status=r.status.value,

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -180,6 +180,7 @@ class ReportStatusUpdate(BaseModel):
 
 
 class ReportForPost(BaseModel):
+    id: int
     reporter_name: Optional[str] = None
     reason: str
     status: ReportStatus


### PR DESCRIPTION
## Summary
- include `id` in `ReportForPost` schema so admin posts return IDs
- pass report IDs from backend when listing posts

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68537c34e25083238e59a567a0c7fa5f