### PR TITLE
Add department mentions

### DIFF
--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -15,6 +15,8 @@ class PostBase(BaseModel):
 class PostCreate(PostBase):
     # IDs of users mentioned in this post
     mention_user_ids: list[int] = []
+    # IDs of departments whose members are mentioned
+    mention_department_ids: list[int] = []
 
 # フロントエンドに返す投稿のデータ型
 class Post(PostBase):


### PR DESCRIPTION
## Summary
- allow specifying department IDs when creating a post
- expand department mentions into individual user mentions
- test department mention behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685383839c68832394e0b398f374ed0e