### PR TITLE
Add like reaction to posts

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -28,6 +28,14 @@ post_department_mentions = Table(
     Column("department_id", ForeignKey("departments.id"), primary_key=True),
 )
 
+# Association table for Post likes
+post_likes = Table(
+    "post_likes",
+    Base.metadata,
+    Column("post_id", ForeignKey("posts.id"), primary_key=True),
+    Column("user_id", ForeignKey("users.id"), primary_key=True),
+)
+
 
 class Department(Base):
     __tablename__ = "departments"
@@ -65,6 +73,12 @@ class User(Base):
         secondary=post_mentions,
         back_populates="mentions",
     )
+    # Posts this user liked
+    liked_posts = relationship(
+        "Post",
+        secondary=post_likes,
+        back_populates="likers",
+    )
 
 class Post(Base):
     __tablename__ = "posts"
@@ -94,6 +108,13 @@ class Post(Base):
         back_populates="mentioned_in",
     )
 
+    # Users who liked this post
+    likers = relationship(
+        "User",
+        secondary=post_likes,
+        back_populates="liked_posts",
+    )
+
     # Departments mentioned in this post
     mention_departments = relationship(
         "Department",
@@ -115,6 +136,10 @@ class Post(Base):
     @property
     def mention_department_ids(self) -> list[int]:
         return [dept.id for dept in self.mention_departments]
+
+    @property
+    def like_count(self) -> int:
+        return len(self.likers)
 
 
 class Report(Base):

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -26,6 +26,8 @@ class Post(PostBase):
     mention_department_ids: list[int] = []
     mention_users: list['MentionTarget'] = []
     mention_departments: list['MentionTarget'] = []
+    like_count: int = 0
+    liked_by_me: bool = False
 
     # ★★★計画書通り、ここには投稿者の情報を含めません★★★
     # これにより、タイムラインの匿名性を保証します。

--- a/backend/app/tests/test_likes.py
+++ b/backend/app/tests/test_likes.py
@@ -1,0 +1,44 @@
+from fastapi.testclient import TestClient
+from ..main import app
+
+
+def _get_token(client: TestClient, username: str, password: str) -> str:
+    resp = client.post("/token", data={"username": username, "password": password})
+    assert resp.status_code == 200
+    return resp.json()["access_token"]
+
+
+def test_like_unlike_flow():
+    with TestClient(app) as client:
+        token = _get_token(client, "000001", "000001")
+        headers = {"Authorization": f"Bearer {token}"}
+
+        post_resp = client.post("/posts/", json={"content": "like me"}, headers=headers)
+        assert post_resp.status_code == 201
+        post_id = post_resp.json()["id"]
+
+        like_resp = client.post(f"/posts/{post_id}/like", headers=headers)
+        assert like_resp.status_code == 204
+
+        posts = client.get("/posts/", headers=headers).json()
+        target = next(p for p in posts if p["id"] == post_id)
+        assert target["like_count"] == 1
+        assert target["liked_by_me"] is True
+
+        # liking again should be idempotent
+        like_resp2 = client.post(f"/posts/{post_id}/like", headers=headers)
+        assert like_resp2.status_code == 204
+        posts = client.get("/posts/", headers=headers).json()
+        target = next(p for p in posts if p["id"] == post_id)
+        assert target["like_count"] == 1
+
+        unlike_resp = client.delete(f"/posts/{post_id}/like", headers=headers)
+        assert unlike_resp.status_code == 204
+        posts = client.get("/posts/", headers=headers).json()
+        target = next(p for p in posts if p["id"] == post_id)
+        assert target["like_count"] == 0
+        assert target["liked_by_me"] is False
+
+        # unauthorized like
+        unauth = client.post(f"/posts/{post_id}/like")
+        assert unauth.status_code == 401

--- a/frontend/src/components/ui/Timeline.tsx
+++ b/frontend/src/components/ui/Timeline.tsx
@@ -10,6 +10,8 @@ interface Post {
   created_at: string; // ISO 8601形式の文字列
   mention_users?: { id: number; name: string | null }[];
   mention_departments?: { id: number; name: string | null }[];
+  like_count?: number;
+  liked_by_me?: boolean;
 }
 
 // 親コンポーネントから受け取るPropsの型を定義


### PR DESCRIPTION
## Summary
- add a `post_likes` association table and relationships
- expose like information through schemas and endpoints
- implement like/unlike endpoints with optimistic UI in frontend
- display like counts and toggleable ♡ icon on posts
- test liking flow

## Testing
- `pytest backend/app/tests/test_likes.py backend/app/tests/test_main.py backend/app/tests/test_admin.py backend/app/tests/test_reports.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68538b90ab048323bed39dcb867b7616