### PR TITLE
Fix duplicate type in CreatePostModal

### DIFF
--- a/frontend/src/components/ui/CreatePostModal.tsx
+++ b/frontend/src/components/ui/CreatePostModal.tsx
@@ -72,11 +72,6 @@ const CreatePostModal: React.FC<CreatePostModalProps> = ({ onClose, onPostSucces
     handleMentionChange(e as unknown as React.ChangeEvent<HTMLInputElement>);
   };
 
-  type UserSearchResult = {
-    id: number;
-    name: string;
-    department_name?: string | null;
-  };
 
   const handleContentChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     if (e.target.value.length <= MAX_CHARS) {


### PR DESCRIPTION
## Summary
- remove second `UserSearchResult` type definition in `CreatePostModal.tsx`

## Testing
- `npm run build` *(fails: 'badgeClass' and 'formatRelativeTime' unused)*
- `npx tsc -p tsconfig.json` *(fails: 'badgeClass' and 'formatRelativeTime' unused)*

------
https://chatgpt.com/codex/tasks/task_e_68538f156ebc8323a67f5de3dadc06fd