### PR TITLE
Show department in user search results

### DIFF
--- a/frontend/src/components/ui/CreatePostModal.tsx
+++ b/frontend/src/components/ui/CreatePostModal.tsx
@@ -256,6 +256,7 @@ const CreatePostModal: React.FC<CreatePostModalProps> = ({ onClose, onPostSucces
                     }}
                   >
                   {u.name}
+                  {u.department_name ? ` (${u.department_name})` : ''}
                   </li>
                 ))}
               </ul>


### PR DESCRIPTION
## Summary
- display user department name in CreatePostModal dropdown when available

## Testing
- `npx eslint . --ext ts,tsx` *(fails: 'badgeClass' and 'formatRelativeTime' unused)*
- `npm run build` *(fails due to TypeScript errors in other files)*

------
https://chatgpt.com/codex/tasks/task_e_685394cd48408323aa072c9f7f7e25c3