### PR TITLE
Implement department mention tracking

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -214,6 +214,8 @@ def read_posts(
                 created_at=p.created_at,
                 mention_user_ids=p.mention_user_ids,
                 mention_department_ids=p.mention_department_ids,
+                mention_user_names=p.mention_user_names,
+                mention_department_names=p.mention_department_names,
                 mention_users=[
                     schemas.MentionTarget(
                         id=u.id, name=u.name if u.is_active else "[削除済み]"
@@ -256,6 +258,8 @@ def read_mentioned_posts(
                 created_at=p.created_at,
                 mention_user_ids=p.mention_user_ids,
                 mention_department_ids=p.mention_department_ids,
+                mention_user_names=p.mention_user_names,
+                mention_department_names=p.mention_department_names,
                 mention_users=[
                     schemas.MentionTarget(
                         id=u.id, name=u.name if u.is_active else "[削除済み]"

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -138,6 +138,14 @@ class Post(Base):
         return [dept.id for dept in self.mention_departments]
 
     @property
+    def mention_user_names(self) -> list[str]:
+        return [user.name for user in self.mentions if user.is_active]
+
+    @property
+    def mention_department_names(self) -> list[str]:
+        return [dept.name for dept in self.mention_departments]
+
+    @property
     def like_count(self) -> int:
         return len(self.likers)
 

--- a/backend/app/routers/admin/posts.py
+++ b/backend/app/routers/admin/posts.py
@@ -33,6 +33,9 @@ def list_posts(
                 author_name=p.author.name if p.author else None,
                 department_name=p.author.department.name if p.author and p.author.department else None,
                 mention_user_ids=p.mention_user_ids,
+                mention_department_ids=p.mention_department_ids,
+                mention_user_names=p.mention_user_names,
+                mention_department_names=p.mention_department_names,
                 reports=reports,
                 status=p.report_status,
             )
@@ -65,6 +68,9 @@ def list_deleted_posts(
                 author_name=p.author.name if p.author else None,
                 department_name=p.author.department.name if p.author and p.author.department else None,
                 mention_user_ids=p.mention_user_ids,
+                mention_department_ids=p.mention_department_ids,
+                mention_user_names=p.mention_user_names,
+                mention_department_names=p.mention_department_names,
                 reports=reports,
                 status=p.report_status,
             )

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -24,6 +24,8 @@ class Post(PostBase):
     created_at: datetime
     mention_user_ids: list[int] = []
     mention_department_ids: list[int] = []
+    mention_user_names: list[str] = []
+    mention_department_names: list[str] = []
     mention_users: list['MentionTarget'] = []
     mention_departments: list['MentionTarget'] = []
     like_count: int = 0
@@ -133,6 +135,9 @@ class AdminPost(BaseModel):
     author_name: str
     department_name: Optional[str] = None
     mention_user_ids: list[int] = []
+    mention_department_ids: list[int] = []
+    mention_user_names: list[str] = []
+    mention_department_names: list[str] = []
     reports: list['ReportForPost'] = []
     status: ReportStatus
 

--- a/backend/app/tests/test_admin.py
+++ b/backend/app/tests/test_admin.py
@@ -43,14 +43,24 @@ def test_admin_list_and_delete_posts():
         user = crud.get_user_by_employee_id(db, "000000")
         user_id = user.id
         user_name = user.name
+        dept_id = user.department_id
+        dept_name = user.department.name if user.department else None
         p1 = crud.create_post(
             db,
-            schemas.PostCreate(content="admin post 1", mention_user_ids=[user_id]),
+            schemas.PostCreate(
+                content="admin post 1",
+                mention_user_ids=[user_id],
+                mention_department_ids=[user.department_id],
+            ),
             user_id,
         )
         p2 = crud.create_post(
             db,
-            schemas.PostCreate(content="admin post 2", mention_user_ids=[user_id]),
+            schemas.PostCreate(
+                content="admin post 2",
+                mention_user_ids=[user_id],
+                mention_department_ids=[user.department_id],
+            ),
             user_id,
         )
         p1_id = p1.id
@@ -62,6 +72,9 @@ def test_admin_list_and_delete_posts():
         assert posts[0]["created_at"] >= posts[1]["created_at"]
         assert posts[0]["author_name"] == user_name
         assert user_id in posts[0]["mention_user_ids"]
+        assert dept_id in posts[0]["mention_department_ids"]
+        assert user_name in posts[0]["mention_user_names"]
+        assert posts[0]["mention_department_names"] == [dept_name]
 
         del_resp = client.delete(f"/admin/posts/{p1_id}", headers={"Authorization": f"Bearer {token}"})
         assert del_resp.status_code == 204

--- a/frontend/src/components/ui/CreatePostModal.tsx
+++ b/frontend/src/components/ui/CreatePostModal.tsx
@@ -23,6 +23,7 @@ const CreatePostModal: React.FC<CreatePostModalProps> = ({ onClose, onPostSucces
   const [searchResults, setSearchResults] = useState<UserSearchResult[]>([]);
   const [departments, setDepartments] = useState<Department[]>([]);
   const [selectedMentions, setSelectedMentions] = useState<MentionTarget[]>([]);
+  const [selectedDepartments, setSelectedDepartments] = useState<number[]>([]);
   const [isComposing, setIsComposing] = useState(false);
   const MAX_CHARS = 140;
 
@@ -140,9 +141,7 @@ const CreatePostModal: React.FC<CreatePostModalProps> = ({ onClose, onPostSucces
       const mention_user_ids = selectedMentions
         .filter((m) => m.type === 'user')
         .map((m) => m.id);
-      const mention_department_ids = selectedMentions
-        .filter((m) => m.type === 'department')
-        .map((m) => m.id);
+      const mention_department_ids = selectedDepartments;
       await apiClient.post('/posts/', {
         content,
         mention_user_ids,
@@ -220,7 +219,11 @@ const CreatePostModal: React.FC<CreatePostModalProps> = ({ onClose, onPostSucces
                     const dept = departments.find((d) => d.id === id);
                     if (!dept) return;
                     if (selectedMentions.find((m) => m.id === id)) return;
-                    setSelectedMentions([...selectedMentions, { id, name: dept.name, type: 'department' }]);
+                    setSelectedMentions([
+                      ...selectedMentions,
+                      { id, name: dept.name, type: 'department' },
+                    ]);
+                    setSelectedDepartments([...selectedDepartments, id]);
                     (e.target as HTMLSelectElement).value = '';
                   }}
                   className="w-full p-2 rounded-md text-sm border border-gray-300"
@@ -271,12 +274,19 @@ const CreatePostModal: React.FC<CreatePostModalProps> = ({ onClose, onPostSucces
                   <button
                     type="button"
                     className="ml-1"
-                    onClick={() =>
-                      setSelectedMentions(
-                        selectedMentions.filter((m) => m.id !== u.id),
-                      )
-                    }
-                  >
+                  onClick={() =>
+                      {
+                        setSelectedMentions(
+                          selectedMentions.filter((m) => m.id !== u.id),
+                        );
+                        if (u.type === 'department') {
+                          setSelectedDepartments(
+                            selectedDepartments.filter((d) => d !== u.id),
+                          );
+                        }
+                      }
+                  }
+                >
                     &times;
                   </button>
                 </span>


### PR DESCRIPTION
## Summary
- retain department IDs and names when posts mention departments
- expose mention names via Post and AdminPost schemas
- track selected department IDs separately in the CreatePostModal
- adjust admin and main endpoints to include mention names
- update tests for new department mention fields

## Testing
- `pip install fastapi sqlalchemy uvicorn jaconv passlib[bcrypt] jose pydantic pytest`
- `pip install httpx`
- `pip install python-jose[cryptography] python-dotenv python-multipart requests 'httpx<0.27'`
- `SECRET_KEY='testsecret' pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853a749d4a48323b02af51934c6b434