### PR TITLE
Fix department mentions display

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -2,6 +2,7 @@ from sqlalchemy import Column, Integer, String, DateTime, ForeignKey, Table, Boo
 from sqlalchemy.orm import relationship
 import enum
 from datetime import datetime, timezone
+import jaconv
 
 # No.7で作成したdatabase.pyから、全てのモデルが継承するBaseクラスをインポートします
 from .database import Base
@@ -143,7 +144,13 @@ class Post(Base):
 
     @property
     def mention_department_names(self) -> list[str]:
-        return [dept.name for dept in self.mention_departments]
+        names = []
+        for dept in self.mention_departments:
+            if dept and dept.name:
+                names.append(
+                    jaconv.z2h(dept.name, kana=True, ascii=False, digit=False)
+                )
+        return names
 
     @property
     def like_count(self) -> int:

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -107,6 +107,13 @@ class UserSearchResult(BaseModel):
 class DepartmentBase(BaseModel):
     name: str
 
+    @field_validator("name", mode="before")
+    @classmethod
+    def normalize_name(cls, v: str) -> str:
+        if v is None:
+            return v
+        return jaconv.z2h(v, kana=True, ascii=False, digit=False)
+
 
 class DepartmentCreate(DepartmentBase):
     pass

--- a/backend/app/tests/test_admin.py
+++ b/backend/app/tests/test_admin.py
@@ -2,6 +2,7 @@ from fastapi.testclient import TestClient
 from ..main import app
 from ..database import SessionLocal
 from .. import crud, schemas, models
+import jaconv
 import uuid
 
 
@@ -74,7 +75,9 @@ def test_admin_list_and_delete_posts():
         assert user_id in posts[0]["mention_user_ids"]
         assert dept_id in posts[0]["mention_department_ids"]
         assert user_name in posts[0]["mention_user_names"]
-        assert posts[0]["mention_department_names"] == [dept_name]
+        assert posts[0]["mention_department_names"] == [
+            jaconv.z2h(dept_name, kana=True, ascii=False, digit=False)
+        ]
 
         del_resp = client.delete(f"/admin/posts/{p1_id}", headers={"Authorization": f"Bearer {token}"})
         assert del_resp.status_code == 204
@@ -91,4 +94,5 @@ def test_admin_list_departments():
         resp = client.get("/admin/departments", headers={"Authorization": f"Bearer {token}"})
         assert resp.status_code == 200
         depts = resp.json()
-        assert any(d["name"] == "テスト部署" for d in depts)
+        expected = jaconv.z2h("テスト部署", kana=True, ascii=False, digit=False)
+        assert any(d["name"] == expected for d in depts)

--- a/frontend/src/components/admin/PostAdminPanel.tsx
+++ b/frontend/src/components/admin/PostAdminPanel.tsx
@@ -23,6 +23,8 @@ interface AdminPost {
   author_name: string;
   department_name?: string | null;
   mention_user_ids: number[];
+  mention_user_names?: string[];
+  mention_department_names?: string[];
   reports: Report[];
   status: 'pending' | 'deleted' | 'ignored';
 }
@@ -137,6 +139,13 @@ const PostAdminPanel: React.FC<Props> = ({ showDeleted }) => {
               </span>
             </div>
           <p className="whitespace-pre-wrap mb-2">{post.content}</p>
+          {(post.mention_user_names?.length || 0) +
+            (post.mention_department_names?.length || 0) > 0 && (
+            <p className="text-xs text-gray-500 mb-2">
+              {post.mention_user_names?.map((n) => `@${n}`).join(' ')}{' '}
+              {post.mention_department_names?.map((n) => `@${n}`).join(' ')}
+            </p>
+          )}
           {post.reports.length === 0 ? (
             <p className="text-sm text-gray-500">No reports submitted</p>
           ) : (

--- a/frontend/src/components/ui/ReportModal.tsx
+++ b/frontend/src/components/ui/ReportModal.tsx
@@ -4,6 +4,8 @@ import apiClient from '../../services/api';
 interface Post {
   id: number;
   content: string;
+  mention_user_names?: string[];
+  mention_department_names?: string[];
 }
 
 type ReportModalProps = {
@@ -64,6 +66,13 @@ const ReportModal: React.FC<ReportModalProps> = ({ post, onClose }) => {
         </div>
         <div className="mb-4 p-3 bg-gray-100 rounded text-sm whitespace-pre-wrap">
           {post.content}
+          {(post.mention_user_names?.length || 0) +
+            (post.mention_department_names?.length || 0) > 0 && (
+            <div className="mt-2 text-gray-500 text-xs">
+              {post.mention_user_names?.map((n) => `@${n}`).join(' ')}{' '}
+              {post.mention_department_names?.map((n) => `@${n}`).join(' ')}
+            </div>
+          )}
         </div>
         <form onSubmit={handleSubmit}>
           <textarea


### PR DESCRIPTION
## Summary
- normalize department names to half-width katakana
- expose normalized department names via API
- show department mentions in admin post list and report modal
- update tests for normalized names

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853bdb848748323a3cb689ef3522974