### PR TITLE
Bump FastAPI and require Pydantic 2

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,5 +1,5 @@
 # Webフレームワーク
-fastapi
+fastapi>=0.103
 
 # FastAPIを動かすためのサーバー
 uvicorn[standard]
@@ -19,6 +19,7 @@ python-dotenv
 # Form data parsing for OAuth2PasswordRequestForm
 python-multipart
 jaconv
+pydantic>=2
 
 pytest
 requests


### PR DESCRIPTION
## Summary
- update backend requirements to use `fastapi>=0.103` and `pydantic>=2`
- reinstall Python dependencies
- run tests

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853c3ec5154832381e1fc6c06e934d7