### PR TITLE
Filter inactive users in search

### DIFF
--- a/backend/app/crud.py
+++ b/backend/app/crud.py
@@ -50,7 +50,10 @@ def search_users(db: Session, query: str, limit: int = 10):
     return (
         db.query(models.User)
         .options(joinedload(models.User.department))
-        .filter(models.User.name.like(f"%{query}%"))
+        .filter(
+            models.User.name.like(f"%{query}%"),
+            models.User.is_active == True,
+        )
         .limit(limit)
         .all()
     )


### PR DESCRIPTION
## Summary
- filter out inactive accounts when searching for users

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853c5545ac48323998cd59642803525