### PR TITLE
Refactor department mention handling

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -238,7 +238,11 @@ def read_mentioned_posts(
     current_user: schemas.User = Depends(get_current_user),
 ):
     """Retrieve posts where the current user is mentioned."""
-    posts = crud.get_posts_mentioned(db, user_id=current_user.id)
+    posts = crud.get_posts_mentioned(
+        db,
+        user_id=current_user.id,
+        department_id=current_user.department_id,
+    )
     result = []
     for p in posts:
         result.append(


### PR DESCRIPTION
## Summary
- store department mentions without expanding to user mentions
- include department mentions in mentioned-post retrieval
- update tests for new mention behavior

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854ad50e7f08323b996f0584eba9e0d