### PR TITLE
Add CSV import sample with display_name

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,17 @@ pytest
       * **解決策:** `cp backend/.env.example backend/.env` が実行されていること、および `backend/.env` に有効な設定、特に `SECRET_KEY` と `DATABASE_URL` が含まれていることを確認してください。
   * **Dockerの問題:** Docker Desktop（またはDockerデーモン）が実行されていることを確認してください。
       * **解決策:** Docker Desktopを起動してください。`docker logs <container_name>` を使用して、特定の`Docker`エラーメッセージのログを確認してください。
-  * **`npm install` または `pip install` エラー:** これは通常、ネットワークの問題またはキャッシュの破損を示します。
+* **`npm install` または `pip install` エラー:** これは通常、ネットワークの問題またはキャッシュの破損を示します。
       * **解決策:** npmキャッシュをクリアするか（`npm cache clean --force`）、pipキャッシュをクリアしてみてください。アクティブなインターネット接続があることを確認してください。
+
+## 11\. ユーザーCSVインポート
+
+管理者は `/admin/users/import` エンドポイントからCSVファイルをアップロードしてユーザーを一括作成できます。CSVには以下のヘッダーを含めてください。
+
+```
+user_id,name,display_name,department,email
+```
+
+`display_name` 列がない場合は `name` の値がそのまま表示名として使用されます。サンプルファイル `backend/users_import_template.csv` も参考にしてください。
 
 -----

--- a/backend/users_import_template.csv
+++ b/backend/users_import_template.csv
@@ -1,0 +1,2 @@
+user_id,name,display_name,department,email
+000001,kana1,Sample User,General,example@example.com


### PR DESCRIPTION
## Summary
- provide `backend/users_import_template.csv` example
- document user CSV import headers and fallback behavior in README

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855143a0de48323831cf186cbcbdf53