### PR TITLE
Implement counters update on post creation

### DIFF
--- a/backend/app/crud.py
+++ b/backend/app/crud.py
@@ -188,6 +188,13 @@ def create_post(db: Session, post: schemas.PostCreate, user_id: int):
             db.query(models.User).filter(models.User.id.in_(mentioned_ids)).all()
         )
         db_post.mentions.extend(mentioned_users)
+        for u in mentioned_users:
+            u.appreciated_count += 1
+
+    author = db.query(models.User).filter(models.User.id == user_id).first()
+    if author:
+        author.expressed_count += 1
+
     db.add(db_post)
     db.commit()
     db.refresh(db_post)


### PR DESCRIPTION
## Summary
- update post creation logic to increment counts for author and mentioned users

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a2375cda08323a6b58d3ec0a6cfe5