### PR TITLE
Adjust like counts on author

### DIFF
--- a/backend/app/crud.py
+++ b/backend/app/crud.py
@@ -316,6 +316,8 @@ def like_post(db: Session, post_id: int, user_id: int) -> bool:
     if user in post.likers:
         return True
     post.likers.append(user)
+    if post.author:
+        post.author.likes_received += 1
     db.commit()
     return True
 
@@ -328,6 +330,8 @@ def unlike_post(db: Session, post_id: int, user_id: int) -> bool:
     if user not in post.likers:
         return True
     post.likers.remove(user)
+    if post.author and post.author.likes_received > 0:
+        post.author.likes_received -= 1
     db.commit()
     return True
 


### PR DESCRIPTION
## Summary
- update `like_post` and `unlike_post` to maintain `likes_received` on authors
- extend like flow tests to check author counter

## Testing
- `pip install -q -r backend/requirements.txt`
- `export SECRET_KEY=testkey`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a244cc8e883239e6647882cc9fee3