### PR TITLE
Add count fields to user schemas

### DIFF
--- a/backend/app/routers/admin/users.py
+++ b/backend/app/routers/admin/users.py
@@ -40,6 +40,9 @@ def list_users(
                 is_admin=u.is_admin,
                 is_active=u.is_active,
                 is_logged_in=logged_in,
+                appreciated_count=u.appreciated_count,
+                expressed_count=u.expressed_count,
+                likes_received=u.likes_received,
             )
         )
     return result

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -85,6 +85,9 @@ class User(UserBase):
     department_name: Optional[str] = None
     is_admin: bool = False
     is_active: bool = True
+    appreciated_count: int = 0
+    expressed_count: int = 0
+    likes_received: int = 0
 
     class Config:
         from_attributes = True
@@ -110,6 +113,9 @@ class AdminUser(BaseModel):
     is_admin: bool = False
     is_active: bool = True
     is_logged_in: bool = False
+    appreciated_count: int = 0
+    expressed_count: int = 0
+    likes_received: int = 0
 
     model_config = ConfigDict(from_attributes=True, populate_by_name=True)
 

--- a/backend/app/tests/test_admin.py
+++ b/backend/app/tests/test_admin.py
@@ -241,3 +241,17 @@ def test_admin_list_users_logged_in_naive_timestamp():
         assert resp.status_code == 200
         users = resp.json()
         assert any(u["id"] == user_id and u["is_logged_in"] for u in users)
+
+
+def test_admin_users_include_counts():
+    """Admin users listing should include counter fields"""
+    with TestClient(app) as client:
+        token = _get_admin_token(client)
+        resp = client.get("/admin/users", headers={"Authorization": f"Bearer {token}"})
+        assert resp.status_code == 200
+        users = resp.json()
+        assert users
+        sample = users[0]
+        assert "appreciated_count" in sample
+        assert "expressed_count" in sample
+        assert "likes_received" in sample

--- a/backend/app/tests/test_main.py
+++ b/backend/app/tests/test_main.py
@@ -60,6 +60,28 @@ def test_user_department_name():
         assert user_resp.json().get("department_name") == "テスト部署"
 
 
+def test_user_counts_returned():
+    """/users/me should include appreciation counters"""
+    with TestClient(app) as client:
+        token_resp = client.post(
+            "/token",
+            data={"username": "000000", "password": "pass"},
+        )
+        assert token_resp.status_code == 200
+        token = token_resp.json()["access_token"]
+
+        headers = {"Authorization": f"Bearer {token}"}
+        user_resp = client.get("/users/me", headers=headers)
+        assert user_resp.status_code == 200
+        data = user_resp.json()
+        assert "appreciated_count" in data
+        assert "expressed_count" in data
+        assert "likes_received" in data
+        assert data["appreciated_count"] >= 0
+        assert data["expressed_count"] >= 0
+        assert data["likes_received"] >= 0
+
+
 def test_post_mentions():
     """posts can mention users"""
     with TestClient(app) as client:


### PR DESCRIPTION
## Summary
- add `appreciated_count`, `expressed_count`, `likes_received` to `schemas.User`
- expose these counters in `schemas.AdminUser` and `/admin/users` endpoint
- test that `/users/me` and `/admin/users` return the new fields

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685a2677557c832390e9a1073f019c4e