### PR TITLE
Add ranking admin panel tab

### DIFF
--- a/frontend/src/pages/AdminDashboard.tsx
+++ b/frontend/src/pages/AdminDashboard.tsx
@@ -6,7 +6,7 @@ import TopUsersPanel from '../components/admin/TopUsersPanel';
 
 const AdminDashboard: React.FC = () => {
   const [activeTab, setActiveTab] = useState<
-    'users' | 'departments' | 'deletedPosts' | 'reports'
+    'users' | 'departments' | 'deletedPosts' | 'reports' | 'ranking'
   >('users');
 
   const renderActivePanel = () => {
@@ -17,6 +17,8 @@ const AdminDashboard: React.FC = () => {
         return <PostAdminPanel showDeleted />;
       case 'reports':
         return <PostAdminPanel />;
+      case 'ranking':
+        return <TopUsersPanel />;
       case 'users':
       default:
         return <UserAdminPanel />;
@@ -26,9 +28,6 @@ const AdminDashboard: React.FC = () => {
   return (
     <div className="p-8">
       <h1 className="text-2xl font-bold mb-6">Admin Panel</h1>
-      <div className="mb-6">
-        <TopUsersPanel />
-      </div>
       <div className="mb-4 border-b border-gray-200">
         <div className="flex space-x-4">
           <button
@@ -70,6 +69,16 @@ const AdminDashboard: React.FC = () => {
             }`}
           >
             Reports
+          </button>
+          <button
+            onClick={() => setActiveTab('ranking')}
+            className={`py-2 px-4 font-semibold focus:outline-none ${
+              activeTab === 'ranking'
+                ? 'border-b-2 border-blue-500 text-blue-600'
+                : 'text-gray-500'
+            }`}
+          >
+            Ranking
           </button>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- move ranking boxes from top of admin page into a new Ranking tab
- keep Users tab as the default

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run build` *(fails to compile due to missing dependencies)*
- `pytest` *(fails: SECRET_KEY environment variable not set)*

------
https://chatgpt.com/codex/tasks/task_e_685a4c61112c8323b8e662bf116e66fe